### PR TITLE
return only error for execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation
 ------------
 
 ```
-go get github.com/sony/gobreaker
+go get github.com/influxdata/gobreaker
 ```
 
 Usage
@@ -92,30 +92,22 @@ Example
 ```go
 var cb *breaker.CircuitBreaker
 
-func Get(url string) ([]byte, error) {
-	body, err := cb.Execute(func() (interface{}, error) {
+func Get(url string) (b []byte, err error) {
+	err = cb.Execute(func() error {
 		resp, err := http.Get(url)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		return body, nil
+		return err
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return body.([]byte), nil
+	return b, err
 }
 ```
 
-See [example](https://github.com/sony/gobreaker/blob/master/example) for details.
+See [example](https://github.com/influxdata/gobreaker/blob/master/example) for details.
 
 License
 -------

--- a/example/http_breaker.go
+++ b/example/http_breaker.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/sony/gobreaker"
+	"github.com/influxdata/gobreaker"
 )
 
 var cb *gobreaker.CircuitBreaker
@@ -23,26 +23,18 @@ func init() {
 }
 
 // Get wraps http.Get in CircuitBreaker.
-func Get(url string) ([]byte, error) {
-	body, err := cb.Execute(func() (interface{}, error) {
+func Get(url string) (b []byte, err error) {
+	err = cb.Execute(func() error {
 		resp, err := http.Get(url)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		return body, nil
+		b, err = ioutil.ReadAll(resp.Body)
+		return err
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return body.([]byte), nil
+	return b, err
 }
 
 func main() {
@@ -51,5 +43,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println("%s", string(body))
+	fmt.Println(string(body))
 }

--- a/gobreaker.go
+++ b/gobreaker.go
@@ -191,13 +191,13 @@ func (cb *CircuitBreaker) State() State {
 
 // Execute runs the given request if the CircuitBreaker accepts it.
 // Execute returns an error instantly if the CircuitBreaker rejects the request.
-// Otherwise, Execute returns the result of the request.
+// Otherwise, Execute returns nil.
 // If a panic occurs in the request, the CircuitBreaker handles it as an error
 // and causes the same panic again.
-func (cb *CircuitBreaker) Execute(req func() (interface{}, error)) (interface{}, error) {
+func (cb *CircuitBreaker) Execute(req func() error) error {
 	generation, err := cb.beforeRequest()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	defer func() {
@@ -208,9 +208,9 @@ func (cb *CircuitBreaker) Execute(req func() (interface{}, error)) (interface{},
 		}
 	}()
 
-	result, err := req()
+	err = req()
 	cb.afterRequest(generation, err == nil)
-	return result, err
+	return err
 }
 
 // Name returns the name of the TwoStepCircuitBreaker.

--- a/gobreaker_test.go
+++ b/gobreaker_test.go
@@ -27,18 +27,16 @@ func pseudoSleep(cb *CircuitBreaker, period time.Duration) {
 }
 
 func succeed(cb *CircuitBreaker) error {
-	_, err := cb.Execute(func() (interface{}, error) { return nil, nil })
-	return err
+	return cb.Execute(func() error { return nil })
 }
 
 func succeedLater(cb *CircuitBreaker, delay time.Duration) <-chan error {
 	ch := make(chan error)
 	go func() {
-		_, err := cb.Execute(func() (interface{}, error) {
+		ch <- cb.Execute(func() error {
 			time.Sleep(delay)
-			return nil, nil
+			return nil
 		})
-		ch <- err
 	}()
 	return ch
 }
@@ -55,7 +53,7 @@ func succeed2Step(cb *TwoStepCircuitBreaker) error {
 
 func fail(cb *CircuitBreaker) error {
 	msg := "fail"
-	_, err := cb.Execute(func() (interface{}, error) { return nil, fmt.Errorf(msg) })
+	err := cb.Execute(func() error { return fmt.Errorf(msg) })
 	if err.Error() == msg {
 		return nil
 	}
@@ -73,8 +71,7 @@ func fail2Step(cb *TwoStepCircuitBreaker) error {
 }
 
 func causePanic(cb *CircuitBreaker) error {
-	_, err := cb.Execute(func() (interface{}, error) { panic("oops"); return nil, nil })
-	return err
+	return cb.Execute(func() error { panic("oops") })
 }
 
 func newCustom() *CircuitBreaker {


### PR DESCRIPTION
Make the breaker.Execute only returns error

## Issue

Currently Execute returns result and error, result is an interface, which require casting. The current model won't support the multiple results either. Make it only returns error, will simply the process, and prevent confusion